### PR TITLE
Updates node versions

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Updates the node versions we run the tests on. Removes 12 and older and adds 20 since it's now considered stable