### PR TITLE
Add extract, autocomplete and international autocomplete APIs to apiT…

### DIFF
--- a/examples/international_address_autocomplete.js
+++ b/examples/international_address_autocomplete.js
@@ -23,9 +23,9 @@ await handleRequest(lookup, "Simple Request");
 lookup = new Lookup("Ave", "CAN");
 
 lookup.maxResults = 10;
-// lookup.include_only_administrative_area = "";
-lookup.include_only_locality = "Sherwood Park";
-// lookup.include_only_postal_code = "";
+// lookup.includeOnlyAdministrativeArea = "";
+lookup.includeOnlyLocality = "Sherwood Park";
+// lookup.includeOnlyPostalCode = "";
 
 await handleRequest(lookup, "Using Filter and Prefer");
 

--- a/src/InputData.js
+++ b/src/InputData.js
@@ -10,6 +10,7 @@ class InputData {
 
 	formatData(field) {
 		if (Array.isArray(field)) return field.join(";")
+		else return field;
 	}
 
 	lookupFieldIsPopulated(lookupField) {

--- a/src/InputData.js
+++ b/src/InputData.js
@@ -5,7 +5,11 @@ class InputData {
 	}
 
 	add(apiField, lookupField) {
-		if (this.lookupFieldIsPopulated(lookupField)) this.data[apiField] = this.lookup[lookupField];
+		if (this.lookupFieldIsPopulated(lookupField)) this.data[apiField] = this.formatData(this.lookup[lookupField]);
+	}
+
+	formatData(field) {
+		if (Array.isArray(field)) return field.join(";")
 	}
 
 	lookupFieldIsPopulated(lookupField) {

--- a/src/international_address_autocomplete/Client.js
+++ b/src/international_address_autocomplete/Client.js
@@ -1,6 +1,8 @@
 const Errors = require("../Errors");
 const Request = require("../Request");
 const Suggestion = require("./Suggestion");
+const buildInputData = require("../util/buildInputData");
+const keyTranslationFormat = require("../util/apiToSDKKeyMap").internationalAddressAutocomplete;
 
 class Client {
 	constructor(sender) {
@@ -11,14 +13,7 @@ class Client {
 		if (typeof lookup === "undefined") throw new Errors.UndefinedLookupError();
 
 		let request = new Request();
-		request.parameters = {
-			search: lookup.search,
-			country: lookup.country,
-			max_results: lookup.max_results,
-			include_only_administrative_area: lookup.include_only_administrative_area,
-			include_only_locality: lookup.include_only_locality,
-			include_only_postal_code: lookup.include_only_postal_code,
-		};
+		request.parameters = buildInputData(lookup, keyTranslationFormat);
 
 		return new Promise((resolve, reject) => {
 			this.sender.send(request)

--- a/src/us_autocomplete_pro/Client.js
+++ b/src/us_autocomplete_pro/Client.js
@@ -1,6 +1,8 @@
 const Errors = require("../Errors");
 const Request = require("../Request");
 const Suggestion = require("./Suggestion");
+const buildInputData = require("../util/buildInputData");
+const keyTranslationFormat = require("../util/apiToSDKKeyMap").usAutocompletePro;
 
 /**
  * This client sends lookups to the Smarty US Autocomplete Pro API, <br>
@@ -15,7 +17,7 @@ class Client {
 		if (typeof lookup === "undefined") throw new Errors.UndefinedLookupError();
 
 		let request = new Request();
-		request.parameters = buildRequestParameters(lookup);
+		request.parameters = buildInputData(lookup, keyTranslationFormat)
 
 		return new Promise((resolve, reject) => {
 			this.sender.send(request)
@@ -27,28 +29,6 @@ class Client {
 				})
 				.catch(reject);
 		});
-
-		function buildRequestParameters(lookup) {
-			return {
-				search: lookup.search,
-				selected: lookup.selected,
-				max_results: lookup.maxResults,
-				include_only_cities: joinFieldWith(lookup.includeOnlyCities, ";"),
-				include_only_states: joinFieldWith(lookup.includeOnlyStates, ";"),
-				include_only_zip_codes: joinFieldWith(lookup.includeOnlyZIPCodes, ";"),
-				exclude_states: joinFieldWith(lookup.excludeStates, ";"),
-				prefer_cities: joinFieldWith(lookup.preferCities, ";"),
-				prefer_states: joinFieldWith(lookup.preferStates, ";"),
-				prefer_zip_codes: joinFieldWith(lookup.preferZIPCodes, ";"),
-				prefer_ratio: lookup.preferRatio,
-				prefer_geolocation: lookup.preferGeolocation,
-				source: lookup.source,
-			};
-
-			function joinFieldWith(field, delimiter) {
-				if (field.length) return field.join(delimiter);
-			}
-		}
 
 		function buildSuggestionsFromResponse(payload) {
 			if (payload.suggestions === null) return [];

--- a/src/us_extract/Client.js
+++ b/src/us_extract/Client.js
@@ -1,6 +1,8 @@
 const Errors = require("../Errors");
 const Request = require("../Request");
 const Result = require("./Result");
+const buildInputData = require("../util/buildInputData");
+const keyTranslationFormat = require("../util/apiToSDKKeyMap").usExtract;
 
 /**
  * This client sends lookups to the Smarty US Extract API, <br>
@@ -15,7 +17,7 @@ class Client {
 		if (typeof lookup === "undefined") throw new Errors.UndefinedLookupError();
 
 		let request = new Request(lookup.text);
-		request.parameters = buildRequestParams(lookup);
+		request.parameters = buildInputData(lookup, keyTranslationFormat);
 
 		return new Promise((resolve, reject) => {
 			this.sender.send(request)

--- a/src/util/apiToSDKKeyMap.js
+++ b/src/util/apiToSDKKeyMap.js
@@ -13,6 +13,21 @@ module.exports = {
 		"format": "format",
 		"candidates": "maxCandidates",
 	},
+	usAutocompletePro: {
+		search: "search",
+		selected: "selected",
+		max_results: "maxResults",
+		include_only_cities: "includeOnlyCities",
+		include_only_states: "includeOnlyStates",
+		include_only_zip_codes: "includeOnlyZIPCodes",
+		exclude_states: "excludeStates",
+		prefer_cities: "preferCities",
+		prefer_states: "preferStates",
+		prefer_zip_codes: "preferZIPCodes",
+		prefer_ratio: "preferRatio",
+		prefer_geolocation: "preferGeolocation",
+		source: "source",
+	},
 	usZipcode: {
 		"city": "city",
 		"state": "state",
@@ -32,9 +47,23 @@ module.exports = {
 		"geocode": "geocode",
 		"language": "language",
 	},
+	internationalAddressAutocomplete: {
+		search: "search",
+		country: "country",
+		max_results: "maxResults",
+		include_only_administrative_area: "includeOnlyAdministrativeArea",
+		include_only_locality: "includeOnlyLocality",
+		include_only_postal_code: "includeOnlyPostalCode",
+	},
 	usReverseGeo: {
 		"latitude": "latitude",
 		"longitude": "longitude",
 		"source": "source"
+	},
+	usExtract: {
+		html: "html",
+		aggressive: "aggressive",
+		addr_line_breaks: "addressesHaveLineBreaks",
+		addr_per_line: "addressesPerLine",
 	}
 };

--- a/tests/international_address_autocomplete/test_Client.js
+++ b/tests/international_address_autocomplete/test_Client.js
@@ -11,35 +11,18 @@ describe("An International Address Autocomplete Client", function () {
 	it("correctly builds parameter", function () {
 		let mockSender = new MockSender();
 		let client = new Client(mockSender);
-		let search = "(";
-		let lookup = new Lookup(search);
+		let lookup = new Lookup("a", "b");
+		lookup.maxResults = 10;
+		lookup.includeOnlyAdministrativeArea = "c";
+		lookup.includeOnlyLocality = "d";
+		lookup.includeOnlyPostalCode = "e";
 		let expectedParameters = {
-			search: search,
-			max_results: undefined,
-			include_only_administrative_area: "",
-			include_only_locality: "",
-			include_only_postal_code: "",
-			country: "United States",
-		};
-
-		client.send(lookup);
-		expect(mockSender.request.parameters).to.deep.equal(expectedParameters);
-	});
-
-	it("builds parameters for different country", function () {
-		let mockSender = new MockSender();
-		let client = new Client(mockSender);
-		let search = "(";
-		let lookup = new Lookup(search);
-		lookup.search = search;
-		lookup.country = "Russia";
-		let expectedParameters = {
-			country: "Russia",
-			max_results: undefined,
-			include_only_administrative_area: "",
-			include_only_locality: "",
-			include_only_postal_code: "",
-			search: search,
+			search: "a",
+			country: "b",
+			max_results: 10,
+			include_only_administrative_area: "c",
+			include_only_locality: "d",
+			include_only_postal_code: "e",
 		};
 
 		client.send(lookup);
@@ -52,13 +35,10 @@ describe("An International Address Autocomplete Client", function () {
 		let search = "(";
 		let lookup = new Lookup(search);
 		lookup.search = search;
-		lookup.max_results = 10;
+		lookup.maxResults = 10;
 		let expectedParameters = {
 			country: "United States",
 			max_results: 10,
-			include_only_administrative_area: "",
-			include_only_locality: "",
-			include_only_postal_code: "",
 			search: search,
 		};
 

--- a/tests/us_autocomplete_pro/test_Client.js
+++ b/tests/us_autocomplete_pro/test_Client.js
@@ -15,18 +15,13 @@ describe("A US Autocomplete Pro Client", function () {
 		let lookup = new Lookup(search);
 		let expectedParameters = {
 			search: search,
-			selected: undefined,
-			max_results: undefined,
-			include_only_cities: undefined,
-			include_only_states: undefined,
-			include_only_zip_codes: undefined,
-			exclude_states: undefined,
-			prefer_cities: undefined,
-			prefer_states: undefined,
-			prefer_zip_codes: undefined,
-			prefer_ratio: undefined,
-			prefer_geolocation: undefined,
-			source: undefined,
+			include_only_cities: "",
+			include_only_states: "",
+			include_only_zip_codes: "",
+			exclude_states: "",
+			prefer_cities: "",
+			prefer_states: "",
+			prefer_zip_codes: "",
 		};
 
 		client.send(lookup);


### PR DESCRIPTION
https://app.clickup.com/t/86ayk6mey

The array type Lookup inputs on the US Autocomplete API necessitated a little more logic being added to the InputData class. I feel for consistency across the APIs this would best the best place to move the logic but I don't know what kind of latency this would add to each call or if there's potentially a better place for this. What are your thoughts?