### PR TITLE
add county_source to the sdk

### DIFF
--- a/examples/us_street.js
+++ b/examples/us_street.js
@@ -1,4 +1,4 @@
-const SmartySDK = require("smartystreets-javascript-sdk");
+const SmartySDK = require("../dist/cjs/index.cjs");
 const SmartyCore = SmartySDK.core;
 const Lookup = SmartySDK.usStreet.Lookup;
 
@@ -8,7 +8,8 @@ const Lookup = SmartySDK.usStreet.Lookup;
 // const credentials = new SmartyCore.StaticCredentials(authId, authToken);
 
 // for client-side requests (browser/mobile), use this code:
-let key = process.env.SMARTY_EMBEDDED_KEY;
+// Note: key must be a string
+let key = "your key";
 const credentials = new SmartyCore.SharedCredentials(key);
 
 // The appropriate license values to be used for your subscriptions
@@ -23,37 +24,17 @@ let client = clientBuilder.buildUsStreetApiClient();
 // https://www.smarty.com/docs/us-street-api#input-fields
 
 let lookup1 = new Lookup();
-lookup1.inputId = "24601";  // Optional ID from your system
-lookup1.addressee = "John Doe";
-lookup1.street = "330 N 100 W";
-lookup1.street2 = "closet under the stairs";
-lookup1.secondary = "APT 2";
-lookup1.urbanization = "";  // Only applies to Puerto Rico addresses
-lookup1.city = "Provo";
-lookup1.state = "Utah";
-lookup1.zipCode = "84601";
-lookup1.maxCandidates = 3;
-lookup1.match = "invalid"; // "invalid" is the most permissive match,
-                           // this will always return at least one result even if the address is invalid.
-                           // Refer to the documentation for additional MatchStrategy options.
+lookup1.street = "805 Tye Crossing Ct";
+lookup1.city = "Burleson";
+lookup1.state = "TX";
+lookup1.zipCode = "76028";
+lookup1.candidates = 10;
+lookup1.match = "enhanced";
+// lookup1.countySource = "geographic";
 
-let lookup2 = new Lookup();
-lookup2.street = "1600 Amphitheater Pkwy";
-lookup2.lastLine = "Mountainview, CA";
-lookup2.maxCandidates = 5;
-
-let lookup3 = new Lookup();
-lookup3.inputId = "8675309";
-lookup3.street = "1600 Amphitheatre Parkway Mountain View, CA 94043";
-lookup3.maxCandidates = 1;
-
-// NOTE: batches are not supported when using SharedCredentials.
-let batch = new SmartyCore.Batch();
-batch.add(lookup1);
-batch.add(lookup2);
-batch.add(lookup3);
-
-await handleResponse(batch);
+(async () => {
+	await handleResponse(lookup1);
+})();
 
 function handleSuccess(response) {
 	response.lookups.map(lookup => console.log(lookup.result));

--- a/src/us_street/Lookup.js
+++ b/src/us_street/Lookup.js
@@ -4,7 +4,22 @@
  *     @see "https://www.smarty.com/docs/cloud/us-street-api#input-fields"
  */
 class Lookup {
-	constructor(street, street2, secondary, city, state, zipCode, lastLine, addressee, urbanization, match, maxCandidates, inputId, format) {
+	constructor(
+		street,
+		street2,
+		secondary,
+		city,
+		state,
+		zipCode,
+		lastLine,
+		addressee,
+		urbanization,
+		match,
+		maxCandidates,
+		inputId,
+		format,
+		countySource,
+	) {
 		this.street = street;
 		this.street2 = street2;
 		this.secondary = secondary;
@@ -18,6 +33,7 @@ class Lookup {
 		this.maxCandidates = maxCandidates;
 		this.inputId = inputId;
 		this.format = format;
+		this.countySource = countySource;
 		this.result = [];
 	}
 }

--- a/src/util/apiToSDKKeyMap.js
+++ b/src/util/apiToSDKKeyMap.js
@@ -12,6 +12,7 @@ module.exports = {
 		"match": "match",
 		"format": "format",
 		"candidates": "maxCandidates",
+		"county_source": "countySource"
 	},
 	usAutocompletePro: {
 		search: "search",


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/86b2rzryh 

you may need to run `npm run build` to build the code before testing.

I added an example address to the example file. To test, run the us_street example and see that the output for `county_name` is Johnson and the `county_fips` is 48251.
If you uncomment line 33 in the example, enabling geographic county source, you'll see the output for `county_name` change to Tarrant and `county_fips` change to 48439

Once this is approved I'll revert the changes to `examples/us_street.js`