### PR TITLE
remove axios dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
    "name": "smartystreets-javascript-sdk",
    "version": "0.0.0",
    "license": "Apache-2.0",
-   "dependencies": {
-    "axios": "^1.7.7",
-    "axios-retry": "^4.5.0"
-   },
    "devDependencies": {
     "@babel/preset-env": "^7.25.8",
     "@rollup/plugin-commonjs": "^28.0.1",
@@ -2036,32 +2032,6 @@
     "node": "*"
    }
   },
-  "node_modules/asynckit": {
-   "version": "0.4.0",
-   "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-   "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-  },
-  "node_modules/axios": {
-   "version": "1.7.7",
-   "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-   "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-   "dependencies": {
-    "follow-redirects": "^1.15.6",
-    "form-data": "^4.0.0",
-    "proxy-from-env": "^1.1.0"
-   }
-  },
-  "node_modules/axios-retry": {
-   "version": "4.5.0",
-   "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-   "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-   "dependencies": {
-    "is-retry-allowed": "^2.2.0"
-   },
-   "peerDependencies": {
-    "axios": "0.x || 1.x"
-   }
-  },
   "node_modules/babel-plugin-polyfill-corejs2": {
    "version": "0.4.11",
    "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
@@ -2410,17 +2380,6 @@
    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
    "dev": true
   },
-  "node_modules/combined-stream": {
-   "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-   "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-   "dependencies": {
-    "delayed-stream": "~1.0.0"
-   },
-   "engines": {
-    "node": ">= 0.8"
-   }
-  },
   "node_modules/commander": {
    "version": "2.20.3",
    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2526,14 +2485,6 @@
    },
    "engines": {
     "node": ">=8"
-   }
-  },
-  "node_modules/delayed-stream": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-   "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-   "engines": {
-    "node": ">=0.4.0"
    }
   },
   "node_modules/diff": {
@@ -2656,38 +2607,6 @@
    "dev": true,
    "bin": {
     "flat": "cli.js"
-   }
-  },
-  "node_modules/follow-redirects": {
-   "version": "1.15.9",
-   "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-   "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-   "funding": [
-    {
-     "type": "individual",
-     "url": "https://github.com/sponsors/RubenVerborgh"
-    }
-   ],
-   "engines": {
-    "node": ">=4.0"
-   },
-   "peerDependenciesMeta": {
-    "debug": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/form-data": {
-   "version": "4.0.1",
-   "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-   "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-   "dependencies": {
-    "asynckit": "^0.4.0",
-    "combined-stream": "^1.0.8",
-    "mime-types": "^2.1.12"
-   },
-   "engines": {
-    "node": ">= 6"
    }
   },
   "node_modules/fs.realpath": {
@@ -3009,17 +2928,6 @@
     "@types/estree": "*"
    }
   },
-  "node_modules/is-retry-allowed": {
-   "version": "2.2.0",
-   "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-   "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-   "engines": {
-    "node": ">=10"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/sindresorhus"
-   }
-  },
   "node_modules/is-unicode-supported": {
    "version": "0.1.0",
    "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3229,25 +3137,6 @@
    },
    "engines": {
     "node": ">=8.6"
-   }
-  },
-  "node_modules/mime-db": {
-   "version": "1.52.0",
-   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-   "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-   "engines": {
-    "node": ">= 0.6"
-   }
-  },
-  "node_modules/mime-types": {
-   "version": "2.1.35",
-   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-   "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-   "dependencies": {
-    "mime-db": "1.52.0"
-   },
-   "engines": {
-    "node": ">= 0.6"
    }
   },
   "node_modules/mocha": {
@@ -3484,11 +3373,6 @@
    "funding": {
     "url": "https://github.com/sponsors/jonschlinkert"
    }
-  },
-  "node_modules/proxy-from-env": {
-   "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-   "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
   },
   "node_modules/queue-microtask": {
    "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
   "rollup": "^4.22.5",
   "rollup-plugin-delete": "^2.1.0"
  },
- "dependencies": {
-  "axios": "^1.7.7",
-  "axios-retry": "^4.5.0"
- }
+ "dependencies": {}
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,7 +6,6 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 export default {
   input: "index.mjs",
-  external: ["axios", "axios-retry"],
   output: [
     {
       dir: "dist/cjs",

--- a/src/HttpSender.js
+++ b/src/HttpSender.js
@@ -1,9 +1,9 @@
-const Axios = require("axios").default;
 const {buildSmartyResponse} = require("../src/util/buildSmartyResponse");
+const {newAxiosAdapter} = require("./util/axiosAdapter");
 
 class HttpSender {
 	constructor(timeout = 10000, proxyConfig, debug = false) {
-		this.axiosInstance = Axios.create();
+		this.httpSender = newAxiosAdapter();
 		this.timeout = timeout;
 		this.proxyConfig = proxyConfig;
 		if (debug) this.enableDebug();
@@ -34,7 +34,7 @@ class HttpSender {
 		return new Promise((resolve, reject) => {
 			let requestConfig = this.buildRequestConfig(request);
 
-			this.axiosInstance(requestConfig)
+			this.httpSender(requestConfig)
 				.then(response => {
 					let smartyResponse = buildSmartyResponse(response);
 
@@ -47,13 +47,13 @@ class HttpSender {
 	}
 
 	enableDebug() {
-		this.axiosInstance.interceptors.request.use(request => {
+		this.httpSender.interceptors.request.use(request => {
 			console.log('Request:\r\n', request);
 			console.log('\r\n*******************************************\r\n');
 			return request
 		});
 
-		this.axiosInstance.interceptors.response.use(response => {
+		this.httpSender.interceptors.response.use(response => {
 			console.log('Response:\r\n');
 			console.log('Status:', response.status, response.statusText);
 			console.log('Headers:', response.headers);

--- a/src/util/axiosAdapter.js
+++ b/src/util/axiosAdapter.js
@@ -1,0 +1,81 @@
+function buildParams(data) {
+  const params = new URLSearchParams()
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach(value => params.append(key, value.toString()))
+    } else {
+      params.append(key, value.toString())
+    }
+  });
+
+  return params.toString()
+}
+
+async function axiosAdapter(requestConfig, interceptors){
+  let timeout = 5000
+  if (requestConfig.timeout && typeof requestConfig.timeout !== 'number') {
+    try {
+      timeout = parseInt(requestConfig.timeout);
+    } catch (e) {
+      console.warn(`Timeout set for request to: ${requestConfig.baseURL} is invalid. Got ${requestConfig.timeout}. Using default timeout: ${timeout}`);
+    }
+  }
+  if(interceptors.request.handlers.length > 0){
+    for(const interceptor of interceptors.request.handlers){
+      requestConfig = await interceptor(requestConfig);
+    }
+  }
+  let url = requestConfig.baseURL
+  if(requestConfig.params){
+    url += (url.includes('?') ? '&' : '?') + buildParams(requestConfig.params)
+  }
+
+
+  let res = await fetch(url, {
+    method: requestConfig.method,
+    signal: requestConfig.timeout && AbortSignal.timeout(requestConfig.timeout),
+    headers: requestConfig.headers,
+    body: requestConfig.data,
+    mode: 'cors'
+  })
+
+  if(interceptors.response.handlers.length > 0){
+    for(const interceptor of interceptors.response.handlers){
+      res = await interceptor(res);
+    }
+  }
+  if(typeof requestConfig.validateStatus === 'function'){
+    if(!requestConfig.validateStatus(res.status)){
+      throw new Error(`Request to ${requestConfig.url} failed with status code ${res.status}`);
+    }
+  }
+  if(res.headers.get('content-type') === 'application/json'){
+    res.data = await res.json();
+  } else if(res.headers.get('content-type').includes('text/')) {
+    res.data = await res.text();
+  } else {
+    res.data = await res.blob();
+  }
+  return res;
+}
+
+class InterceptorContainer {
+  constructor () {
+    this.handlers = [];
+  }
+  use(handler) {
+    this.handlers.push(handler);
+  }
+}
+
+// Create a minimal adapter that provides some of the functionality that axios provides, such as interceptors
+module.exports = {
+  buildParams,
+  newAxiosAdapter () {
+    const interceptors = {request: new InterceptorContainer(), response: new InterceptorContainer()}
+    const adapter = (requestConfig)=> axiosAdapter(requestConfig, interceptors);
+    adapter.interceptors = interceptors;
+    return adapter
+  }
+}

--- a/tests/test_HttpSender.js
+++ b/tests/test_HttpSender.js
@@ -4,7 +4,7 @@ const Request = require("../src/Request");
 const HttpSender = require("../src/HttpSender");
 const {buildSmartyResponse} = require("../src/util/buildSmartyResponse");
 
-describe ("An Axios implementation of a HTTP sender", function () {
+describe ("A fetch implementation of a HTTP sender", function () {
 	it("adds a data payload to the HTTP request config.", function () {
 		let expectedPayload = "test payload";
 		let request = new Request(expectedPayload);

--- a/tests/util/test_axiosAdapter.js
+++ b/tests/util/test_axiosAdapter.js
@@ -1,0 +1,143 @@
+const chai = require("chai");
+const expect = chai.expect;
+const { newAxiosAdapter, buildParams } = require("../../src/util/axiosAdapter.js");
+
+describe("AxiosAdapter functionality", function () {
+  const fakeFetch = async (url, options) => {
+    let contentType;
+    if (url.includes("json")) {
+      contentType = "application/json";
+    } else if (url.includes("text")) {
+      contentType = "text/plain";
+    } else {
+      contentType = "application/octet-stream";
+    }
+
+    return {
+      status: 200,
+      headers: {
+        get: (header) => header === "content-type" ? contentType : null,
+      },
+      json: async () => ({ message: "test" }),
+      text: async () => "test text",
+      blob: async () => new Blob(["test"], { type: "application/octet-stream" })
+    };
+  };
+
+  let oldFetch;
+
+  before(function () {
+    oldFetch = global.fetch;
+    global.fetch = fakeFetch;
+  });
+
+  after(function () {
+    global.fetch = oldFetch;
+  });
+
+  it("should call request interceptors", async function () {
+    const adapter = newAxiosAdapter();
+    const interceptorCalled = [];
+
+    adapter.interceptors.request.use((config) => {
+      interceptorCalled.push("request");
+      return config;
+    });
+
+    await adapter({
+      method: "GET",
+      baseURL: "https://example.com/json",
+    });
+
+    expect(interceptorCalled).to.deep.equal(["request"]);
+  });
+
+  it("should call response interceptors", async function () {
+    const adapter = newAxiosAdapter();
+    const interceptorCalled = [];
+
+    adapter.interceptors.response.use((res) => {
+      interceptorCalled.push("response");
+      return res;
+    });
+
+    await adapter({
+      method: "GET",
+      baseURL: "https://example.com/json",
+    });
+
+    expect(interceptorCalled).to.deep.equal(["response"]);
+  });
+
+  it("should build param string correctly and append to URL", async function () {
+    let data = { search: "test", sort: ["asc", "desc"] }
+    const queryParams = buildParams(data)
+    
+    expect(queryParams).to.equal("search=test&sort=asc&sort=desc");
+    const parsed = {}
+    let parsedParams = new URLSearchParams(queryParams)
+    for (const key of parsedParams.keys()) {
+      if(parsed[key]) continue
+      let allValues = parsedParams.getAll(key)
+      parsed[key] = allValues;
+      if (allValues.length <=1) {
+        parsed[key] = allValues[0];
+      }
+    }
+    expect(parsed).to.deep.equal(data);
+  });
+
+  it("should throw error for invalid status code", async function () {
+    const adapter = newAxiosAdapter();
+    const requestConfig = {
+      method: "GET",
+      baseURL: "https://example.com/json",
+      validateStatus: (status) => status !== 200,
+    };
+
+    let error;
+
+    try {
+      await adapter(requestConfig);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.be.an("Error");
+    expect(error.message).to.include("failed with status code 200");
+  });
+
+  it("should process JSON response correctly", async function () {
+    const adapter = newAxiosAdapter();
+
+    const response = await adapter({
+      method: "GET",
+      baseURL: "https://example.com/json",
+    });
+
+    expect(response.data).to.deep.equal({ message: "test" });
+  });
+
+  it("should process text response correctly", async function () {
+    const adapter = newAxiosAdapter();
+
+    const response = await adapter({
+      method: "GET",
+      baseURL: "https://example.com/text",
+    });
+
+    expect(response.data).to.equal("test text");
+  });
+
+  it("should process blob response correctly", async function () {
+    const adapter = newAxiosAdapter();
+
+    const response = await adapter({
+      method: "GET",
+      baseURL: "https://example.com/blob",
+    });
+
+    expect(response.data).to.be.instanceOf(Blob);
+    expect(response.data.type).to.equal("application/octet-stream");
+  });
+});


### PR DESCRIPTION
This change removes the axios library as a dependency and uses native fetch instead. It uses a shim for fetch to make it work with the existing interface and implements the functionality as needed. 

Now that IE 11 is deprecated, all major browsers support fetch.

https://caniuse.com/fetch

This should help shrink the bundle size for this sdk.
