### PR TITLE
make max candidates default for us-street-api be 1 - the same as the api itself.

### DIFF
--- a/src/us_street/Client.js
+++ b/src/us_street/Client.js
@@ -29,7 +29,7 @@ class Client {
 
 		if (dataIsLookup) {
 			if (data.maxCandidates == null && data.match == "enhanced")
-				data.maxCandidates = 5;
+				data.maxCandidates = 1;
 			batch = new Batch();
 			batch.add(data);
 		} else {

--- a/tests/us_street/test_Client.js
+++ b/tests/us_street/test_Client.js
@@ -49,14 +49,14 @@ describe("A US Street client", function () {
 		expect(mockSender.request.parameters).to.deep.equal(expectedParameters);
 	});
 
-	it("defaults maxCandidates to 5 when match type is enhanced.", function () {
+	it("defaults maxCandidates to 1 when match type is enhanced.", function () {
 		let mockSender = new MockSender();
 		const client = new Client(mockSender);
 		let lookup = new Lookup();
 		lookup.match = "enhanced";
 		let expectedParameters = {
 			match: "enhanced",
-			candidates: 5,
+			candidates: 1,
 		};
 
 		client.send(lookup);


### PR DESCRIPTION
make max candidates default for us-street-api be 1 - the same as the api itself.