### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/examples/us_enrichment_etag.mjs
+++ b/examples/us_enrichment_etag.mjs
@@ -1,4 +1,4 @@
-import SmartySDK, { NotModifiedError } from "smartystreets-javascript-sdk";
+import SmartySDK from "smartystreets-javascript-sdk";
 
 const SmartyCore = SmartySDK.core;
 const { BusinessSummaryLookup, BusinessDetailLookup } = SmartySDK.usEnrichment;
@@ -23,15 +23,11 @@ async function demoSummaryEtag(smartyKey) {
 
 	const second = new BusinessSummaryLookup(smartyKey);
 	second.requestEtag = capturedEtag;
-	try {
-		await client.sendBusinessSummary(second);
+	await client.sendBusinessSummary(second);
+	if (!second.results) {
+		console.log("Second call: 304 Not Modified; refreshed etag:", second.responseEtag);
+	} else {
 		console.log("Second call: 200, new responseEtag:", second.responseEtag);
-	} catch (err) {
-		if (err instanceof NotModifiedError) {
-			console.log("Second call: 304 Not Modified; refreshed etag:", err.responseEtag);
-		} else {
-			throw err;
-		}
 	}
 }
 
@@ -46,20 +42,16 @@ async function demoDetailEtag(businessId) {
 
 	const second = new BusinessDetailLookup(businessId);
 	second.requestEtag = first.responseEtag;
-	try {
-		await client.sendBusinessDetail(second);
+	await client.sendBusinessDetail(second);
+	if (!second.result) {
+		console.log("Second call: 304 Not Modified; refreshed etag:", second.responseEtag);
+	} else {
 		console.log("Second call: 200, new responseEtag:", second.responseEtag);
-	} catch (err) {
-		if (err instanceof NotModifiedError) {
-			console.log("Second call: 304 Not Modified; refreshed etag:", err.responseEtag);
-		} else {
-			throw err;
-		}
 	}
 }
 
 async function main() {
-	const smartyKey = "334968275";
+	const smartyKey = "1962995076";
 	await demoSummaryEtag(smartyKey);
 
 	const summary = new BusinessSummaryLookup(smartyKey);

--- a/examples/us_enrichment_etag.ts
+++ b/examples/us_enrichment_etag.ts
@@ -3,7 +3,6 @@ import {
 	BasicAuthCredentials,
 	BusinessSummaryLookup,
 	BusinessDetailLookup,
-	NotModifiedError,
 } from "smartystreets-javascript-sdk";
 
 const authId = process.env.SMARTY_AUTH_ID!;
@@ -26,15 +25,11 @@ async function demoSummaryEtag(smartyKey: string): Promise<void> {
 
 	const second = new BusinessSummaryLookup(smartyKey);
 	second.requestEtag = capturedEtag;
-	try {
-		await client.sendBusinessSummary(second);
+	await client.sendBusinessSummary(second);
+	if (!second.results) {
+		console.log("Second call: 304 Not Modified; refreshed etag:", second.responseEtag);
+	} else {
 		console.log("Second call: 200, new responseEtag:", second.responseEtag);
-	} catch (err: unknown) {
-		if (err instanceof NotModifiedError) {
-			console.log("Second call: 304 Not Modified; refreshed etag:", err.responseEtag);
-		} else {
-			throw err;
-		}
 	}
 }
 
@@ -49,20 +44,16 @@ async function demoDetailEtag(businessId: string): Promise<void> {
 
 	const second = new BusinessDetailLookup(businessId);
 	second.requestEtag = first.responseEtag;
-	try {
-		await client.sendBusinessDetail(second);
+	await client.sendBusinessDetail(second);
+	if (!second.result) {
+		console.log("Second call: 304 Not Modified; refreshed etag:", second.responseEtag);
+	} else {
 		console.log("Second call: 200, new responseEtag:", second.responseEtag);
-	} catch (err: unknown) {
-		if (err instanceof NotModifiedError) {
-			console.log("Second call: 304 Not Modified; refreshed etag:", err.responseEtag);
-		} else {
-			throw err;
-		}
 	}
 }
 
 async function main(): Promise<void> {
-	const smartyKey = "334968275";
+	const smartyKey = "1962995076";
 	await demoSummaryEtag(smartyKey);
 
 	const summary = new BusinessSummaryLookup(smartyKey);

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,94 +1,137 @@
+// Each class sets `name` to an explicit string (rather than relying on
+// constructor.name) so the value survives minification and works across
+// duplicate copies of this package, where instanceof checks can fail.
 export class SmartyError extends Error {
 	constructor(message: string = "unexpected error") {
 		super(message);
+		this.name = "SmartyError";
 	}
 }
 
 export class DefaultError extends SmartyError {
 	constructor(message?: string | null) {
 		super(message || "unexpected error");
+		this.name = "DefaultError";
 	}
 }
 
 export class BatchFullError extends SmartyError {
 	constructor() {
 		super("A batch can contain a max of 100 lookups.");
+		this.name = "BatchFullError";
 	}
 }
 
 export class BatchEmptyError extends SmartyError {
 	constructor() {
 		super("A batch must contain at least 1 lookup.");
+		this.name = "BatchEmptyError";
 	}
 }
 
 export class UndefinedLookupError extends SmartyError {
 	constructor() {
 		super("The lookup provided is missing or undefined. Make sure you're passing a Lookup object.");
+		this.name = "UndefinedLookupError";
 	}
 }
 
 export class BadCredentialsError extends SmartyError {
-	constructor() {
+	constructor(message?: string) {
 		super(
-			"Unauthorized: The credentials were provided incorrectly or did not match any existing active credentials.",
+			message ??
+				"Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.",
 		);
+		this.name = "BadCredentialsError";
 	}
 }
 
 export class PaymentRequiredError extends SmartyError {
-	constructor() {
+	constructor(message?: string) {
 		super(
-			"Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.",
+			message ??
+				"Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.",
 		);
+		this.name = "PaymentRequiredError";
+	}
+}
+
+export class ForbiddenError extends SmartyError {
+	constructor(message?: string) {
+		super(
+			message ??
+				"Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.",
+		);
+		this.name = "ForbiddenError";
+	}
+}
+
+export class RequestTimeoutError extends SmartyError {
+	constructor(message?: string) {
+		super(message ?? "Request timeout error.");
+		this.name = "RequestTimeoutError";
 	}
 }
 
 export class RequestEntityTooLargeError extends SmartyError {
-	constructor() {
-		super("Request Entity Too Large: The request body has exceeded the maximum size.");
+	constructor(message?: string) {
+		super(message ?? "Request Entity Too Large: The request body has exceeded the maximum size.");
+		this.name = "RequestEntityTooLargeError";
 	}
 }
 
 export class BadRequestError extends SmartyError {
-	constructor() {
+	constructor(message?: string) {
 		super(
-			"Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.",
+			message ??
+				"Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.",
 		);
+		this.name = "BadRequestError";
 	}
 }
 
 export class UnprocessableEntityError extends SmartyError {
-	constructor(message: string) {
-		super(message);
+	constructor(message?: string) {
+		super(message ?? "GET request lacked required fields.");
+		this.name = "UnprocessableEntityError";
 	}
 }
 
 export class TooManyRequestsError extends SmartyError {
-	constructor() {
-		super(
-			"When using the public 'embedded key' authentication, we restrict the number of requests coming from a given source over too short of a time.",
-		);
+	constructor(message?: string) {
+		super(message ?? "Too Many Requests: The rate limit for your account has been exceeded.");
+		this.name = "TooManyRequestsError";
 	}
 }
 
 export class InternalServerError extends SmartyError {
-	constructor() {
-		super("Internal Server Error.");
+	constructor(message?: string) {
+		super(message ?? "Internal Server Error.");
+		this.name = "InternalServerError";
+	}
+}
+
+export class BadGatewayError extends SmartyError {
+	constructor(message?: string) {
+		super(message ?? "Bad Gateway error.");
+		this.name = "BadGatewayError";
 	}
 }
 
 export class ServiceUnavailableError extends SmartyError {
-	constructor() {
-		super("Service Unavailable. Try again later.");
+	constructor(message?: string) {
+		super(message ?? "Service Unavailable. Try again later.");
+		this.name = "ServiceUnavailableError";
 	}
 }
 
 export class GatewayTimeoutError extends SmartyError {
-	constructor() {
+	constructor(message?: string) {
 		super(
-			"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.",
+			message ??
+				"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.",
 		);
+		this.name = "GatewayTimeoutError";
 	}
 }
 
@@ -98,8 +141,9 @@ export class NotModifiedError extends SmartyError {
 	constructor(message?: string, responseEtag?: string) {
 		super(
 			message ??
-				"Not Modified: the requested record has not changed since the previous request with the Etag value.",
+				"Not Modified: The requested record has not been modified since the previous request with the Etag value.",
 		);
+		this.name = "NotModifiedError";
 		this.responseEtag = responseEtag;
 	}
 }
@@ -111,11 +155,14 @@ export default {
 	UndefinedLookupError,
 	BadCredentialsError,
 	PaymentRequiredError,
+	ForbiddenError,
+	RequestTimeoutError,
 	RequestEntityTooLargeError,
 	BadRequestError,
 	UnprocessableEntityError,
 	TooManyRequestsError,
 	InternalServerError,
+	BadGatewayError,
 	ServiceUnavailableError,
 	GatewayTimeoutError,
 	NotModifiedError,

--- a/src/HttpSender.ts
+++ b/src/HttpSender.ts
@@ -135,11 +135,12 @@ export default class HttpSender {
 	private async parseResponseBody(
 		response: globalThis.Response,
 	): Promise<object[] | object | string | null> {
+		const text = await response.text();
+		if (!text) return null;
 		const contentType = response.headers.get("content-type") ?? "";
 		if (contentType.includes("application/json")) {
-			return await response.json();
+			return JSON.parse(text);
 		}
-		const text = await response.text();
-		return text || null;
+		return text;
 	}
 }

--- a/src/StatusCodeSender.ts
+++ b/src/StatusCodeSender.ts
@@ -1,8 +1,17 @@
 import {
-	InternalServerError,
-	ServiceUnavailableError,
+	BadCredentialsError,
+	BadGatewayError,
+	BadRequestError,
+	ForbiddenError,
 	GatewayTimeoutError,
+	InternalServerError,
 	NotModifiedError,
+	PaymentRequiredError,
+	RequestEntityTooLargeError,
+	RequestTimeoutError,
+	ServiceUnavailableError,
+	TooManyRequestsError,
+	UnprocessableEntityError,
 	DefaultError,
 } from "./Errors.js";
 import { Request, Response, Sender } from "./types.js";
@@ -13,6 +22,27 @@ function extractEtag(headers: Record<string, string> | undefined): string | unde
 		if (key.toLowerCase() === "etag") return headers[key];
 	}
 	return undefined;
+}
+
+// Pulls the message(s) out of the API's JSON error body ({"errors":[{"message":"..."}]}),
+// returning undefined when the payload is missing, unparseable, or carries no messages,
+// so callers fall back to the standard message for the status code.
+function messageFrom(payload: Response["payload"]): string | undefined {
+	let parsed = payload;
+	if (typeof parsed === "string") {
+		try {
+			parsed = JSON.parse(parsed);
+		} catch {
+			return undefined;
+		}
+	}
+	const errors = (parsed as { errors?: { message?: string }[] } | null)?.errors;
+	if (!Array.isArray(errors)) return undefined;
+	const message = errors
+		.map((error) => error?.message ?? "")
+		.filter((text) => text.trim() !== "")
+		.join(" ");
+	return message === "" ? undefined : message;
 }
 
 export default class StatusCodeSender {
@@ -34,6 +64,7 @@ export default class StatusCodeSender {
 					resolve(response);
 				},
 				(error: Response) => {
+					const message = messageFrom(error.payload);
 					switch (error.statusCode) {
 						case 0:
 							error.error = error.error ?? new DefaultError("Network error: unable to connect.");
@@ -43,24 +74,60 @@ export default class StatusCodeSender {
 							error.error = new NotModifiedError(undefined, extractEtag(error.headers));
 							break;
 
+						case 400:
+							error.error = new BadRequestError(message);
+							break;
+
+						case 401:
+							error.error = new BadCredentialsError(message);
+							break;
+
+						case 402:
+							error.error = new PaymentRequiredError(message);
+							break;
+
+						case 403:
+							error.error = new ForbiddenError(message);
+							break;
+
+						case 408:
+							error.error = new RequestTimeoutError(message);
+							break;
+
+						case 413:
+							error.error = new RequestEntityTooLargeError(message);
+							break;
+
+						case 422:
+							error.error = new UnprocessableEntityError(message);
+							break;
+
+						case 429:
+							error.error = new TooManyRequestsError(message);
+							break;
+
 						case 500:
-							error.error = new InternalServerError();
+							error.error = new InternalServerError(message);
+							break;
+
+						case 502:
+							error.error = new BadGatewayError(message);
 							break;
 
 						case 503:
-							error.error = new ServiceUnavailableError();
+							error.error = new ServiceUnavailableError(message);
 							break;
 
 						case 504:
-							error.error = new GatewayTimeoutError();
+							error.error = new GatewayTimeoutError(message);
 							break;
 
 						default: {
-							const payload = error.payload as {
-								errors?: { message?: string }[];
-							} | null;
-							const message = payload?.errors?.[0]?.message;
-							error.error = new DefaultError(message ?? error.error?.message);
+							error.error = new DefaultError(
+								message ??
+									error.error?.message ??
+									`The server returned an unexpected HTTP status code: ${error.statusCode}`,
+							);
 						}
 					}
 					reject(error);

--- a/src/StatusCodeSender.ts
+++ b/src/StatusCodeSender.ts
@@ -5,7 +5,6 @@ import {
 	ForbiddenError,
 	GatewayTimeoutError,
 	InternalServerError,
-	NotModifiedError,
 	PaymentRequiredError,
 	RequestEntityTooLargeError,
 	RequestTimeoutError,
@@ -15,14 +14,6 @@ import {
 	DefaultError,
 } from "./Errors.js";
 import { Request, Response, Sender } from "./types.js";
-
-function extractEtag(headers: Record<string, string> | undefined): string | undefined {
-	if (!headers) return undefined;
-	for (const key of Object.keys(headers)) {
-		if (key.toLowerCase() === "etag") return headers[key];
-	}
-	return undefined;
-}
 
 function unusedBody(payload: Response["payload"]): string {
 	if (payload == null) return "";
@@ -59,11 +50,6 @@ export default class StatusCodeSender {
 		return new Promise((resolve, reject) => {
 			this.sender.send(request).then(
 				(response) => {
-					if (response.statusCode === 304) {
-						response.error = new NotModifiedError(undefined, extractEtag(response.headers));
-						reject(response);
-						return;
-					}
 					resolve(response);
 				},
 				(error: Response) => {
@@ -71,10 +57,6 @@ export default class StatusCodeSender {
 					switch (error.statusCode) {
 						case 0:
 							error.error = error.error ?? new DefaultError("Network error: unable to connect.");
-							break;
-
-						case 304:
-							error.error = new NotModifiedError(undefined, extractEtag(error.headers));
 							break;
 
 						case 400:

--- a/src/StatusCodeSender.ts
+++ b/src/StatusCodeSender.ts
@@ -24,9 +24,12 @@ function extractEtag(headers: Record<string, string> | undefined): string | unde
 	return undefined;
 }
 
-// Pulls the message(s) out of the API's JSON error body ({"errors":[{"message":"..."}]}),
-// returning undefined when the payload is missing, unparseable, or carries no messages,
-// so callers fall back to the standard message for the status code.
+function unusedBody(payload: Response["payload"]): string {
+	if (payload == null) return "";
+	const raw = typeof payload === "string" ? payload : JSON.stringify(payload);
+	return raw?.trim() ?? "";
+}
+
 function messageFrom(payload: Response["payload"]): string | undefined {
 	let parsed = payload;
 	if (typeof parsed === "string") {
@@ -129,6 +132,10 @@ export default class StatusCodeSender {
 									`The server returned an unexpected HTTP status code: ${error.statusCode}`,
 							);
 						}
+					}
+					if (!message && error.statusCode !== 0 && error.statusCode !== 304 && error.error) {
+						error.error.message =
+							`${error.error.message} Body: ${unusedBody(error.payload)}`.trimEnd();
 					}
 					reject(error);
 				},

--- a/src/us_autocomplete_pro/Client.ts
+++ b/src/us_autocomplete_pro/Client.ts
@@ -29,9 +29,9 @@ export default class Client {
 
 					const payload = response.payload as {
 						suggestions: RawUsAutocompleteSuggestion[] | null;
-					};
+					} | null;
 					lookup.result =
-						payload.suggestions === null
+						!payload || payload.suggestions === null
 							? []
 							: payload.suggestions.map((suggestion) => new Suggestion(suggestion));
 					resolve(lookup);

--- a/src/us_enrichment/Client.ts
+++ b/src/us_enrichment/Client.ts
@@ -154,14 +154,16 @@ export default class Client {
 			this.sender
 				.send(request)
 				.then((response) => {
-					if (response.error) return reject(response.error);
 					this.captureResponseEtag(response, lookup);
+					if (response.statusCode === 304) {
+						return resolve(lookup);
+					}
 					onPayload(response.payload as Record<string, unknown>);
 					resolve(lookup);
 				})
 				.catch((err: unknown) => {
 					// StatusCodeSender rejects with the Response wrapper (with .error set).
-					// Unwrap so consumers can catch SmartyError subclasses like NotModifiedError directly.
+					// Unwrap so consumers can catch SmartyError subclasses directly.
 					const inner =
 						err && typeof err === "object" && "error" in err && (err as { error: unknown }).error;
 					reject(inner || err);

--- a/src/us_extract/Client.ts
+++ b/src/us_extract/Client.ts
@@ -37,12 +37,14 @@ export default class Client {
 				.then((response) => {
 					if (response.error) return reject(response.error);
 
-					lookup.result = new Result(
-						response.payload as {
-							meta: RawExtractMeta;
-							addresses: RawExtractAddress[];
-						},
-					);
+					if (response.payload) {
+						lookup.result = new Result(
+							response.payload as {
+								meta: RawExtractMeta;
+								addresses: RawExtractAddress[];
+							},
+						);
+					}
 					resolve(lookup);
 				})
 				.catch(reject);

--- a/src/util/sendBatch.ts
+++ b/src/util/sendBatch.ts
@@ -39,12 +39,14 @@ export default function sendBatch(
 	}
 
 	function assignResultsToLookups(batch: Batch, response: Response): Batch {
-		(response.payload as Record<string, any>[]).forEach((rawResult: Record<string, any>) => {
-			const result = new Result(rawResult);
-			const lookup = batch.getByIndex(result.inputIndex);
+		((response.payload as Record<string, any>[]) ?? []).forEach(
+			(rawResult: Record<string, any>) => {
+				const result = new Result(rawResult);
+				const lookup = batch.getByIndex(result.inputIndex);
 
-			lookup.result.push(result);
-		});
+				lookup.result.push(result);
+			},
+		);
 
 		return batch;
 	}

--- a/tests/test_Errors.ts
+++ b/tests/test_Errors.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import errors from "../src/Errors.js";
+
+describe("Smarty error classes", function () {
+	const expectedNames: Record<string, string> = {
+		SmartyError: "SmartyError",
+		DefaultError: "DefaultError",
+		BatchFullError: "BatchFullError",
+		BatchEmptyError: "BatchEmptyError",
+		UndefinedLookupError: "UndefinedLookupError",
+		BadCredentialsError: "BadCredentialsError",
+		PaymentRequiredError: "PaymentRequiredError",
+		ForbiddenError: "ForbiddenError",
+		RequestTimeoutError: "RequestTimeoutError",
+		RequestEntityTooLargeError: "RequestEntityTooLargeError",
+		BadRequestError: "BadRequestError",
+		UnprocessableEntityError: "UnprocessableEntityError",
+		TooManyRequestsError: "TooManyRequestsError",
+		InternalServerError: "InternalServerError",
+		BadGatewayError: "BadGatewayError",
+		ServiceUnavailableError: "ServiceUnavailableError",
+		GatewayTimeoutError: "GatewayTimeoutError",
+		NotModifiedError: "NotModifiedError",
+	};
+
+	it("sets an explicit name on every error class so it survives minification.", function () {
+		for (const [exportName, expectedName] of Object.entries(expectedNames)) {
+			const ErrorClass = (errors as any)[exportName];
+			const instance = new ErrorClass();
+			expect(instance.name, exportName).to.equal(expectedName);
+		}
+	});
+
+	it("keeps the name when a custom message is supplied.", function () {
+		const error = new errors.BadCredentialsError("message from the API");
+		expect(error.name).to.equal("BadCredentialsError");
+		expect(error.message).to.equal("message from the API");
+	});
+
+	it("extends SmartyError and Error for every class.", function () {
+		for (const exportName of Object.keys(expectedNames)) {
+			const ErrorClass = (errors as any)[exportName];
+			const instance = new ErrorClass();
+			expect(instance, exportName).to.be.an.instanceOf(errors.SmartyError);
+			expect(instance, exportName).to.be.an.instanceOf(Error);
+		}
+	});
+});

--- a/tests/test_StatusCodeSender.ts
+++ b/tests/test_StatusCodeSender.ts
@@ -158,6 +158,33 @@ describe("A status code sender", function () {
 		return expectedErrorWithPayloadMessage(418, payload, errors.DefaultError, "API teapot message");
 	});
 
+	it("appends an unparseable string body to the fallback message.", function () {
+		return expectedErrorWithPayloadMessage(
+			422,
+			"not json",
+			errors.UnprocessableEntityError,
+			"GET request lacked required fields. Body: not json",
+		);
+	});
+
+	it("appends a message-less object body to the fallback message.", function () {
+		return expectedErrorWithPayloadMessage(
+			422,
+			{ errors: [] },
+			errors.UnprocessableEntityError,
+			'GET request lacked required fields. Body: {"errors":[]}',
+		);
+	});
+
+	it("labels a blank body with an empty Body marker.", function () {
+		return expectedErrorWithPayloadMessage(
+			422,
+			"   ",
+			errors.UnprocessableEntityError,
+			"GET request lacked required fields. Body:",
+		);
+	});
+
 	it("rejects with NotModifiedError on a 304 and captures lowercase etag header", function () {
 		const response = new Response(304, null, null, { etag: "abc-123" });
 		const mockSender = { send: () => Promise.resolve(response) };
@@ -261,7 +288,7 @@ function expectedErrorWithFallbackMessage(
 		},
 		(error) => {
 			expect(error.error).to.be.an.instanceOf(expectedError);
-			expect(error.error.message).to.be.equal(expectedMessage);
+			expect(error.error.message).to.be.equal(`${expectedMessage} Body:`);
 		},
 	);
 }

--- a/tests/test_StatusCodeSender.ts
+++ b/tests/test_StatusCodeSender.ts
@@ -26,23 +26,136 @@ describe("A status code sender", function () {
 		const payload = {
 			errors: [{ message: "custom message" }],
 		};
-		return expectedErrorWithPayloadMessage(400, payload);
+		return expectedErrorWithPayloadMessage(400, payload, errors.BadRequestError, "custom message");
 	});
 
-	it("returns an error message if payload is undefined", function () {
-		return expectedDefaultError();
+	it("falls back to the standard message if payload is undefined", function () {
+		return expectedErrorWithFallbackMessage(
+			400,
+			errors.BadRequestError,
+			"Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.",
+		);
+	});
+
+	it("gives a Bad Credentials error on a 401.", function () {
+		return expectedErrorWithFallbackMessage(
+			401,
+			errors.BadCredentialsError,
+			"Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.",
+		);
+	});
+
+	it("gives a Payment Required error on a 402.", function () {
+		return expectedErrorWithFallbackMessage(
+			402,
+			errors.PaymentRequiredError,
+			"Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.",
+		);
+	});
+
+	it("gives a Forbidden error on a 403.", function () {
+		return expectedErrorWithFallbackMessage(
+			403,
+			errors.ForbiddenError,
+			"Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.",
+		);
+	});
+
+	it("gives a Request Timeout error on a 408.", function () {
+		return expectedErrorWithFallbackMessage(
+			408,
+			errors.RequestTimeoutError,
+			"Request timeout error.",
+		);
+	});
+
+	it("gives a Request Entity Too Large error on a 413.", function () {
+		return expectedErrorWithFallbackMessage(
+			413,
+			errors.RequestEntityTooLargeError,
+			"Request Entity Too Large: The request body has exceeded the maximum size.",
+		);
+	});
+
+	it("gives an Unprocessable Entity error on a 422.", function () {
+		return expectedErrorWithFallbackMessage(
+			422,
+			errors.UnprocessableEntityError,
+			"GET request lacked required fields.",
+		);
+	});
+
+	it("gives a Too Many Requests error on a 429.", function () {
+		return expectedErrorWithFallbackMessage(
+			429,
+			errors.TooManyRequestsError,
+			"Too Many Requests: The rate limit for your account has been exceeded.",
+		);
 	});
 
 	it("gives an Internal Server Error on a 500.", function () {
-		return expectedErrorForStatusCode(errors.InternalServerError, 500);
+		return expectedErrorWithFallbackMessage(
+			500,
+			errors.InternalServerError,
+			"Internal Server Error.",
+		);
+	});
+
+	it("gives a Bad Gateway error on a 502.", function () {
+		return expectedErrorWithFallbackMessage(502, errors.BadGatewayError, "Bad Gateway error.");
 	});
 
 	it("gives an Service Unavailable error on a 503.", function () {
-		return expectedErrorForStatusCode(errors.ServiceUnavailableError, 503);
+		return expectedErrorWithFallbackMessage(
+			503,
+			errors.ServiceUnavailableError,
+			"Service Unavailable. Try again later.",
+		);
 	});
 
 	it("gives an Gateway Timeout error on a 504.", function () {
-		return expectedErrorForStatusCode(errors.GatewayTimeoutError, 504);
+		return expectedErrorWithFallbackMessage(
+			504,
+			errors.GatewayTimeoutError,
+			"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.",
+		);
+	});
+
+	it("uses the API message for a 500 when present.", function () {
+		const payload = { errors: [{ message: "API broke" }] };
+		return expectedErrorWithPayloadMessage(500, payload, errors.InternalServerError, "API broke");
+	});
+
+	it("joins multiple API messages.", function () {
+		const payload = { errors: [{ message: "First problem." }, { message: "Second problem." }] };
+		return expectedErrorWithPayloadMessage(
+			422,
+			payload,
+			errors.UnprocessableEntityError,
+			"First problem. Second problem.",
+		);
+	});
+
+	it("parses the API message from a JSON string payload.", function () {
+		return expectedErrorWithPayloadMessage(
+			401,
+			JSON.stringify({ errors: [{ message: "bad credentials from api" }] }),
+			errors.BadCredentialsError,
+			"bad credentials from api",
+		);
+	});
+
+	it("gives a Default error with the standard message for an unexpected status code.", function () {
+		return expectedErrorWithFallbackMessage(
+			418,
+			errors.DefaultError,
+			"The server returned an unexpected HTTP status code: 418",
+		);
+	});
+
+	it("uses the API message for an unexpected status code when present.", function () {
+		const payload = { errors: [{ message: "API teapot message" }] };
+		return expectedErrorWithPayloadMessage(418, payload, errors.DefaultError, "API teapot message");
 	});
 
 	it("rejects with NotModifiedError on a 304 and captures lowercase etag header", function () {
@@ -112,43 +225,43 @@ describe("A status code sender", function () {
 	});
 });
 
-const expectedErrorWithPayloadMessage = (errorCode: any, payload: any) => {
+const expectedErrorWithPayloadMessage = (
+	errorCode: any,
+	payload: any,
+	expectedError: any,
+	expectedMessage: string,
+) => {
 	let mockSender = generateMockSender(errorCode, payload);
 	let statusCodeSender = new StatusCodeSender(mockSender as any);
 	let request = new Request();
 
 	return statusCodeSender.send(request).then(
-		() => {},
+		() => {
+			throw new Error("expected rejection");
+		},
 		(error) => {
-			expect(error.error).to.be.an.instanceOf(errors.DefaultError);
-			expect(error.error.message).to.be.equal(payload.errors[0].message);
+			expect(error.error).to.be.an.instanceOf(expectedError);
+			expect(error.error.message).to.be.equal(expectedMessage);
 		},
 	);
 };
 
-const expectedDefaultError = () => {
-	let mockSender = generateMockSender(400);
-	let statusCodeSender = new StatusCodeSender(mockSender as any);
-	let request = new Request();
-
-	return statusCodeSender.send(request).then(
-		() => {},
-		(error) => {
-			expect(error.error).to.be.an.instanceOf(errors.DefaultError);
-			expect(error.error.message).to.be.equal("unexpected error");
-		},
-	);
-};
-
-function expectedErrorForStatusCode(expectedError: any, errorCode: any) {
+function expectedErrorWithFallbackMessage(
+	errorCode: any,
+	expectedError: any,
+	expectedMessage: string,
+) {
 	let mockSender = generateMockSender(errorCode);
 	let statusCodeSender = new StatusCodeSender(mockSender as any);
 	let request = new Request();
 
 	return statusCodeSender.send(request).then(
-		() => {},
+		() => {
+			throw new Error("expected rejection");
+		},
 		(error) => {
 			expect(error.error).to.be.an.instanceOf(expectedError);
+			expect(error.error.message).to.be.equal(expectedMessage);
 		},
 	);
 }

--- a/tests/test_StatusCodeSender.ts
+++ b/tests/test_StatusCodeSender.ts
@@ -185,70 +185,16 @@ describe("A status code sender", function () {
 		);
 	});
 
-	it("rejects with NotModifiedError on a 304 and captures lowercase etag header", function () {
+	it("resolves a 304 as success and passes the response through untouched", function () {
 		const response = new Response(304, null, null, { etag: "abc-123" });
 		const mockSender = { send: () => Promise.resolve(response) };
 		const statusCodeSender = new StatusCodeSender(mockSender as any);
 
-		return statusCodeSender.send(new Request()).then(
-			() => {
-				throw new Error("expected rejection");
-			},
-			(rejected) => {
-				expect(rejected.statusCode).to.equal(304);
-				expect(rejected.error).to.be.an.instanceOf(errors.NotModifiedError);
-				expect(rejected.error.responseEtag).to.equal("abc-123");
-			},
-		);
-	});
-
-	it("rejects with NotModifiedError on a 304 and captures mixed-case ETag header", function () {
-		const response = new Response(304, null, null, { ETag: "srv-2" });
-		const mockSender = { send: () => Promise.resolve(response) };
-		const statusCodeSender = new StatusCodeSender(mockSender as any);
-
-		return statusCodeSender.send(new Request()).then(
-			() => {
-				throw new Error("expected rejection");
-			},
-			(rejected) => {
-				expect(rejected.error).to.be.an.instanceOf(errors.NotModifiedError);
-				expect(rejected.error.responseEtag).to.equal("srv-2");
-			},
-		);
-	});
-
-	it("rejects with NotModifiedError with undefined responseEtag when the Etag header is absent", function () {
-		const response = new Response(304, null, null, {});
-		const mockSender = { send: () => Promise.resolve(response) };
-		const statusCodeSender = new StatusCodeSender(mockSender as any);
-
-		return statusCodeSender.send(new Request()).then(
-			() => {
-				throw new Error("expected rejection");
-			},
-			(rejected) => {
-				expect(rejected.error).to.be.an.instanceOf(errors.NotModifiedError);
-				expect(rejected.error.responseEtag).to.equal(undefined);
-			},
-		);
-	});
-
-	it("handles a 304 that was thrown (rather than resolved) by the inner sender", function () {
-		const response = new Response(304, null, null, { Etag: "thrown" });
-		const mockSender = { send: () => Promise.reject(response) };
-		const statusCodeSender = new StatusCodeSender(mockSender as any);
-
-		return statusCodeSender.send(new Request()).then(
-			() => {
-				throw new Error("expected rejection");
-			},
-			(rejected) => {
-				expect(rejected.statusCode).to.equal(304);
-				expect(rejected.error).to.be.an.instanceOf(errors.NotModifiedError);
-				expect(rejected.error.responseEtag).to.equal("thrown");
-			},
-		);
+		return statusCodeSender.send(new Request()).then((resolved) => {
+			expect(resolved.statusCode).to.equal(304);
+			expect(resolved.error == null).to.equal(true);
+			expect(resolved.headers["etag"]).to.equal("abc-123");
+		});
 	});
 });
 

--- a/tests/us_enrichment/test_BusinessClient.ts
+++ b/tests/us_enrichment/test_BusinessClient.ts
@@ -307,26 +307,22 @@ describe("Client.sendBusinessDetail", function () {
 });
 
 describe("Client error unwrapping", function () {
-	it("rejects with NotModifiedError directly when the sender rejects with a Response wrapper (304)", function () {
-		const notModified = new errors.NotModifiedError(undefined, "srv-etag");
-		const wrapper = {
-			statusCode: 304,
-			payload: null,
-			error: notModified,
-			headers: { etag: "srv-etag" },
+	it("resolves successfully on a 304 response and refreshes the etag", function () {
+		const okSender = {
+			send: () =>
+				Promise.resolve({
+					statusCode: 304,
+					payload: null,
+					error: null,
+					headers: { etag: "srv-etag" },
+				}),
 		};
-		const failingSender = { send: () => Promise.reject(wrapper) };
-		const client = new Client(failingSender as any);
+		const client = new Client(okSender as any);
+		const lookup = new SummaryLookup("sk");
 
-		return client.sendBusinessSummary(new SummaryLookup("sk")).then(
-			() => {
-				throw new Error("expected rejection");
-			},
-			(err) => {
-				expect(err).to.be.an.instanceOf(errors.NotModifiedError);
-				expect(err.responseEtag).to.equal("srv-etag");
-			},
-		);
+		return client.sendBusinessSummary(lookup).then(() => {
+			expect(lookup.responseEtag).to.equal("srv-etag");
+		});
 	});
 
 	it("rejects with the inner InternalServerError for a wrapped 500", function () {

--- a/tests/us_enrichment/test_Client.ts
+++ b/tests/us_enrichment/test_Client.ts
@@ -427,9 +427,7 @@ describe("A US Enrichment Client", function () {
 				street_name: "Main",
 				street_suffix: "St",
 			},
-			secondaries: [
-				{ smarty_key: "s1", secondary_designator: "Apt", secondary_number: "101" },
-			],
+			secondaries: [{ smarty_key: "s1", secondary_designator: "Apt", secondary_number: "101" }],
 		};
 		let expectedResponse = new SecondaryResponse(rawMockPayload);
 
@@ -474,6 +472,28 @@ describe("A US Enrichment Client", function () {
 		client.sendPrincipal(lookup);
 
 		expect(mockSender.request.headers).to.not.have.property("Etag");
+	});
+
+	it("treats a 304 as success with refreshed etag and untouched results", function () {
+		const mockSender = {
+			send: () =>
+				Promise.resolve({
+					statusCode: 304,
+					payload: null,
+					error: null,
+					headers: { etag: "refreshed-etag" },
+				}),
+		};
+		const client = new Client(mockSender as any);
+		const lookup = new Lookup("sk");
+		lookup.requestEtag = "old-etag";
+		lookup.response = "prior" as any;
+
+		return client.sendPrincipal(lookup).then((resolved) => {
+			expect(resolved).to.equal(lookup);
+			expect(lookup.responseEtag).to.equal("refreshed-etag");
+			expect(lookup.response).to.equal("prior");
+		});
 	});
 
 	it("captures responseEtag from lowercase etag header on sendPrincipal", function () {


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- 400/401/402/403/408/413/422/429 now reject with their specific error classes (previously `DefaultError`); added `ForbiddenError`/`RequestTimeoutError`/`BadGatewayError`.
- Every error class sets an explicit `name` so it survives minification and duplicate package copies; `rejected.statusCode` is unchanged for property-based checks.
- Note for consumers: `instanceof DefaultError` checks for 4xx statuses will no longer match; use the specific classes, `error.name`, or `statusCode`.

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
